### PR TITLE
Fix segfault by invalid margin value

### DIFF
--- a/stag.c
+++ b/stag.c
@@ -76,10 +76,15 @@ int main(int argc, char **argv) {
 
       case 'm':
         // Margin
-        graph.margins->t = atoi(strsep(&optarg, ","));
-        graph.margins->r = atoi(strsep(&optarg, ","));
-        graph.margins->b = atoi(strsep(&optarg, ","));
-        graph.margins->l = atoi(strsep(&optarg, ","));
+        if(sscanf(optarg,
+                  "%d,%d,%d,%d",
+                  &graph.margins->t,
+                  &graph.margins->r,
+                  &graph.margins->b,
+                  &graph.margins->l) != 4) {
+          printf("%s not recognized as input to --margin. See --help\n", optarg);
+          exit(1);
+        }
         break;
 
       case 's':


### PR DESCRIPTION
If any of the values missing, it will result in segmentation fault, e.g.

```
-m 0
-m 0,1
```

Use `scanf` to help ensure the format is correct and prevent the segfault from happening.

By the way, there is no `--help`, I just copied the error message from scale's.
