### PR TITLE
Updated MakeFile for compatability with linux mint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS=-Wall -Werror -Wextra -std=c99 -pedantic -Wno-unused-parameter
+CFLAGS=-Wall -Werror -Wextra -std=gnu99 -pedantic -Wno-unused-parameter
 # D_BSD_SOURCE for strsep
 LIBS=-lncurses -lm -D_DEFAULT_SOURCE
 PREFIX ?= /usr/local


### PR DESCRIPTION
-c99 for the standard causes the code to fail with an implicit
declaration of the function strsep as well as errors from atoi making a
pointer from an integer without a cast. Updating the makefile to use the
gnu99 standard resolves these errors.

For reference:

    uname -a
    Linux Turing 3.2.0-23-generic #36-Ubuntu SMP Tue Apr 10 20:39:51 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux