### PR TITLE
Make axis_label bigger to prevent out-of-bounds access

### DIFF
--- a/view.c
+++ b/view.c
@@ -87,7 +87,7 @@ void draw_y_axis(graph_t *graph) {
     mvwaddch(y_win->win, i, 0, ACS_VLINE);
 
   // Draw axis values
-  char axis_label[4];
+  char axis_label[5];
   // Max
   mvwaddch(y_win->win, 0, 0, ACS_LTEE);
   format_axis_value(&axis_label[0], max);


### PR DESCRIPTION
stag kept crashing when the maximum value fed into it exceeded 100 000 000.
After increasing the size of axis_label, this stopped ("100M\0" is 5 bytes
long, but axis_label was only able to hold 4 bytes).