### PR TITLE
Fix compilation with clang

### DIFF
--- a/stag.c
+++ b/stag.c
@@ -47,7 +47,7 @@ const char stag_usage_string[] =
 "\n";
 
 // Display usage info
-void usage(){
+void usage(void){
   printf(stag_usage_string);
   exit(0);
 }


### PR DESCRIPTION
Fix compilation error:
```
clang -Wall -Werror -Wextra -std=c99 -pedantic -Wno-unused-parameter stag.c view.c data.c -o stag -lncurses -lm -D_DEFAULT_SOURCE 
stag.c:50:11: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
void usage(){
```